### PR TITLE
pamspiderweb fruits drop cobwebs when sheared

### DIFF
--- a/src/main/resources/data/pamhc2trees/loot_tables/blocks/pamspiderweb.json
+++ b/src/main/resources/data/pamhc2trees/loot_tables/blocks/pamspiderweb.json
@@ -3,7 +3,7 @@
   "pools": [
     {
       "rolls": 1,
-      "name": "pamalmond0",
+      "name": "pamspiderweb0",
       "entries": [
 	{
           "type": "minecraft:alternatives",
@@ -36,7 +36,7 @@
                   ]
                 }
               ],
-              "name": "pamhc2trees:pamapple"
+              "name": "minecraft:cobweb"
             },
         {
           "type": "minecraft:item",


### PR DESCRIPTION
currently they drop apples (bug)
of the 2 methods to fix this, pamspiderweb block or minecraft:cobweb, it was noted that shearing for actual cobwebs may help peaceful players that dont want to mineshaft adventure. that's the route i went.