### PR TITLE
Register ConfiguredFeatures and cleaned up code a bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# eclipse
+bin
+*.launch
+.settings
+.metadata
+.classpath
+.project
+
+# idea
+out
+*.ipr
+*.iws
+*.iml
+.idea
+
+# gradle
+build
+.gradle
+
+# other
+eclipse
+run
+.gitattributes
+deps
+
+# Files from Forge MDK
+forge*changelog.txt
+/.apt_generated/

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // @file build.gradle
 // pamhc2trees mod gradle build relay (mc1.15.2)
 buildscript {
-  repositories {
-    maven { url = 'https://files.minecraftforge.net/maven' }
-    jcenter()
-    mavenCentral()
-  }
-  dependencies {
-    classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '3.+', changing: true
-  }
+    repositories {
+        maven { url = 'https://files.minecraftforge.net/maven' }
+        jcenter()
+        mavenCentral()
+    }
+    dependencies {
+        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '3.+', changing: true
+    }
 }
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
@@ -18,87 +18,90 @@ sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = co
 version = "${version_pamhc2trees}"
 group = "com.pam.pamhc2trees"
 archivesBaseName = "pamhc2trees-${version_minecraft}"
- 
- 
+
+
 repositories {
-  maven { name = "Progwml6 maven"; url = "https://dvs1.progwml6.com/files/maven/" } // JEI files
-  maven { name = "ModMaven"; url = "modmaven.k-4u.nl" } // JEI files, fallback
+    maven { name = "Progwml6 maven"; url = "https://dvs1.progwml6.com/files/maven/" } // JEI files
+    maven { name = "ModMaven"; url = "modmaven.k-4u.nl" } // JEI files, fallback
 }
- 
+
 minecraft {
-  mappings channel: 'snapshot', version: "${version_fml_mappings}"
-  // accessTransformer = file('build/resources/main/META-INF/accesstransformer.cfg')
-  runs {
-    client {
-				workingDirectory project.file('run')
-				property 'forge.logging.markers', ''
-				property 'forge.logging.console.level', 'debug'
-				property 'forge.logging.noansi', "false"
+    mappings channel: 'snapshot', version: "${version_fml_mappings}"
+    // accessTransformer = file('build/resources/main/META-INF/accesstransformer.cfg')
+    runs {
+        client {
+            workingDirectory project.file('run')
+            property 'forge.logging.markers', ''
+            property 'forge.logging.console.level', 'debug'
+            property 'forge.logging.noansi', "false"
+            mods {
+                pamhc2trees {
+                    source sourceSets.main
+                }
+            }
+        }
+        server {
+            workingDirectory project.file('run')
+            property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
+            property 'forge.logging.console.level', 'debug'
+            mods {
+                pamhc2trees {
+                    source sourceSets.main
+                }
+            }
+        }
+        data {
+            workingDirectory project.file('run')
+            property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
+            property 'forge.logging.console.level', 'debug'
+            args '--mod', 'pamhc2trees', '--all', '--output', file('src/generated/resources/')
+            mods {
+                pamhc2trees {
+                    source sourceSets.main
+                }
+            }
+        }
+    }
+}
 
-				environment 'MOD_CLASSES', "${project.file("bin/default").canonicalPath}"
-}
-    server {
-      workingDirectory project.file('run')
-      property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
-      property 'forge.logging.console.level', 'debug'
-      mods {
-        pamhc2trees {
-          source sourceSets.main
-        }
-      }
-    }
-    data {
-      workingDirectory project.file('run')
-      property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
-      property 'forge.logging.console.level', 'debug'
-      args '--mod', 'pamhc2trees', '--all', '--output', file('src/generated/resources/')
-      mods {
-        pamhc2trees {
-          source sourceSets.main
-        }
-      }
-    }
-  }
-}
- 
 dependencies {
-  minecraft "net.minecraftforge:forge:${version_forge_minecraft}"
+    minecraft "net.minecraftforge:forge:${version_forge_minecraft}"
 
 }
- 
+
 processResources {
-  outputs.upToDateWhen { false } // thx to @tterrag for this hint
-  doLast { file("${sourceSets.main.output.resourcesDir}/.gitversion").text = 'git log "-1" "--format=%h"'.execute().in.text.trim() }
+    outputs.upToDateWhen { false } // thx to @tterrag for this hint
+    doLast { file("${sourceSets.main.output.resourcesDir}/.gitversion").text = 'git log "-1" "--format=%h"'.execute().in.text.trim() }
 
-  from(sourceSets.main.resources.srcDirs) {
-    include 'META-INF/mods.toml'
+    from(sourceSets.main.resources.srcDirs) {
+        include 'META-INF/mods.toml'
 
-    expand 'version':project.version
-  }
+        expand 'version': project.version
+    }
 
-  from(sourceSets.main.resources.srcDirs) {
-    exclude 'META-INF/mods.toml'
-  }
+    from(sourceSets.main.resources.srcDirs) {
+        exclude 'META-INF/mods.toml'
+    }
 }
- 
+
 jar {
-  manifest {
-    attributes([
-      "Specification-Title": "pamhc2trees",
-      "Specification-Vendor": "pam",
-      "Specification-Version": "1", // We are version 1 of ourselves
-      "Implementation-Title": project.name,
-      "Implementation-Version": "${version_pamhc2trees}",
-      "Implementation-Vendor" :"pam",
-      "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
-    ])
-  }
+    manifest {
+        attributes([
+                "Specification-Title"     : "pamhc2trees",
+                "Specification-Vendor"    : "pam",
+                "Specification-Version"   : "1", // We are version 1 of ourselves
+                "Implementation-Title"    : project.name,
+                "Implementation-Version"  : "${version_pamhc2trees}",
+                "Implementation-Vendor"   : "pam",
+                "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
+        ])
+    }
 }
- 
+
 def reobfFile = file("$buildDir/reobfJar/output.jar")
 def reobfArtifact = artifacts.add('default', reobfFile) { type 'jar'; builtBy 'reobfJar'; }
- 
+
 publishing {
-  publications { mavenJava(MavenPublication) { artifact reobfArtifact } }
-  repositories { maven { url "file:///${project.projectDir}/mcmodsrepo" } }
+    publications { mavenJava(MavenPublication) { artifact reobfArtifact } }
+    repositories { maven { url "file:///${project.projectDir}/mcmodsrepo" } }
 }

--- a/src/main/java/com/pam/pamhc2trees/init/ColdFruitTreeWorldGenRegistry.java
+++ b/src/main/java/com/pam/pamhc2trees/init/ColdFruitTreeWorldGenRegistry.java
@@ -15,56 +15,38 @@ import net.minecraftforge.event.world.BiomeLoadingEvent;
 
 public class ColdFruitTreeWorldGenRegistry {
 	
-	public static void register(BiomeLoadingEvent evt) {
+	public static void addToBiomes(BiomeLoadingEvent evt) {
 		Set<BiomeDictionary.Type> types = BiomeDictionary.getTypes(RegistryKey.getOrCreateKey(Registry.BIOME_KEY, evt.getName()));
 		//maple
 		if (WorldGenRegistry.maple_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.CONIFEROUS)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.maple_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
-								
+						TreeConfiguredFeatures.MAPLE_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.COLD)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.maple_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.MAPLE_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.HILLS) && types.contains(BiomeDictionary.Type.COLD)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.maple_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.MAPLE_WORLDGEN);
 			}
 		}
 		//pinenut
 		if (WorldGenRegistry.pinenut_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.CONIFEROUS)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.pinenut_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PINENUT_WORLDGEN);
 								
 			}
 			if (types.contains(BiomeDictionary.Type.COLD)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.pinenut_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PINENUT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.HILLS) && types.contains(BiomeDictionary.Type.COLD)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.pinenut_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PINENUT_WORLDGEN);
 			}
-		}		
-
-				
-				
-		
+		}
 	}
-
 }

--- a/src/main/java/com/pam/pamhc2trees/init/TemperateFruitTreeWorldGenRegistry.java
+++ b/src/main/java/com/pam/pamhc2trees/init/TemperateFruitTreeWorldGenRegistry.java
@@ -15,364 +15,262 @@ import net.minecraftforge.event.world.BiomeLoadingEvent;
 
 public class TemperateFruitTreeWorldGenRegistry {
 	
-	public static void register(BiomeLoadingEvent evt) {
+	public static void addToBiome(BiomeLoadingEvent evt) {
 		Set<BiomeDictionary.Type> types = BiomeDictionary.getTypes(RegistryKey.getOrCreateKey(Registry.BIOME_KEY, evt.getName()));
 		if ((evt.getClimate().temperature >= 1F || evt.getClimate().temperature < 0.2F) && !types.contains(BiomeDictionary.Type.SPOOKY)) return;
 		//apple
 		if (WorldGenRegistry.apple_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.FOREST)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.apple_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.APPLE_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.HILLS)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.apple_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.APPLE_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SPOOKY)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.apple_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.APPLE_WORLDGEN);
 			}
 		}
 		//avocado
 		if (WorldGenRegistry.avocado_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.FOREST)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.avocado_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.AVOCADO_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.HILLS)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.avocado_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.AVOCADO_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SPOOKY)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.avocado_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.AVOCADO_WORLDGEN);
 			}
 		}
 		//candlenut
 		if (WorldGenRegistry.candlenut_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.FOREST)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.candlenut_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.CANDLENUT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.HILLS)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.candlenut_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.CANDLENUT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SPOOKY)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.candlenut_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.CANDLENUT_WORLDGEN);
 			}
 		}
 		//cherry
 		if (WorldGenRegistry.cherry_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.FOREST)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.cherry_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.CHERRY_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.HILLS)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.cherry_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.CHERRY_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SPOOKY)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.cherry_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.CHERRY_WORLDGEN);
 			}
 		}
 		//chestnut
 		if (WorldGenRegistry.chestnut_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.FOREST)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.chestnut_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.CHESTNUT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.HILLS)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.chestnut_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.CHESTNUT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SPOOKY)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.chestnut_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.CHESTNUT_WORLDGEN);
 			}
 		}
 		//gooseberry
 		if (WorldGenRegistry.gooseberry_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.FOREST)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.gooseberry_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.GOOSEBERRY_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.HILLS)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.gooseberry_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.GOOSEBERRY_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SPOOKY)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.gooseberry_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.GOOSEBERRY_WORLDGEN);
 			}
 		}
 		//lemon
 		if (WorldGenRegistry.lemon_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.FOREST)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.lemon_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.LEMON_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.HILLS)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.lemon_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.LEMON_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SPOOKY)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.lemon_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.LEMON_WORLDGEN);
 			}
 		}
 		//nutmeg
 		if (WorldGenRegistry.nutmeg_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.FOREST)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.nutmeg_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.NUTMEG_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.HILLS)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.nutmeg_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.NUTMEG_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SPOOKY)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.nutmeg_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.NUTMEG_WORLDGEN);
 			}
 		}
 		//orange
 		if (WorldGenRegistry.orange_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.FOREST)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.orange_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.ORANGE_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.HILLS)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.orange_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.ORANGE_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SPOOKY)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.orange_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.ORANGE_WORLDGEN);
 			}
 		}
 		//peach
 		if (WorldGenRegistry.peach_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.FOREST)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.peach_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.PEACH_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.HILLS)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.peach_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.PEACH_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SPOOKY)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.peach_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PEACH_WORLDGEN);
 			}
 		}
 		//pear
 		if (WorldGenRegistry.pear_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.FOREST)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.pear_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.PEAR_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.HILLS)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.pear_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.PEAR_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SPOOKY)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.pear_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PEAR_WORLDGEN);
 			}
 		}
 		//plum
 		if (WorldGenRegistry.plum_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.FOREST)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.plum_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.PLUM_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.HILLS)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.plum_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.PLUM_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SPOOKY)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.plum_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PLUM_WORLDGEN);
 			}
 		}
 		//walnut
 		if (WorldGenRegistry.walnut_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.FOREST)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.walnut_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.WALNUT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.HILLS)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.walnut_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.WALNUT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SPOOKY)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.walnut_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.WALNUT_WORLDGEN);
 			}
 		}
 		//spiderweb
 		if (WorldGenRegistry.avocado_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.FOREST)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.avocado_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.SPIDERWEB_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.HILLS)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.avocado_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.SPIDERWEB_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SPOOKY)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.avocado_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.SPIDERWEB_WORLDGEN);
 			}
 		}
 		//hazelnut
 		if (WorldGenRegistry.hazelnut_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.FOREST)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.hazelnut_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.HAZELNUT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.HILLS)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.hazelnut_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.HAZELNUT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SPOOKY)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.hazelnut_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.HAZELNUT_WORLDGEN);
 			}
 		}
 		//pawpaw
 		if (WorldGenRegistry.pawpaw_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.FOREST)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.pawpaw_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.PAWPAW_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.HILLS)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.pawpaw_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.PAWPAW_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SPOOKY)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.pawpaw_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PAWPAW_WORLDGEN);
 			}
 		}
 		//soursop
 		if (WorldGenRegistry.soursop_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.FOREST)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.soursop_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.SOURSOP_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.HILLS)) {
 						evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-								WorldGenRegistry.soursop_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-								.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-								.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+								TreeConfiguredFeatures.SOURSOP_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SPOOKY)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.soursop_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.SOURSOP_WORLDGEN);
 			}
 		}
 		

--- a/src/main/java/com/pam/pamhc2trees/init/TreeConfiguredFeatures.java
+++ b/src/main/java/com/pam/pamhc2trees/init/TreeConfiguredFeatures.java
@@ -1,0 +1,137 @@
+package com.pam.pamhc2trees.init;
+
+import com.pam.pamhc2trees.Pamhc2trees;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.WorldGenRegistries;
+import net.minecraft.world.gen.feature.*;
+import net.minecraft.world.gen.placement.AtSurfaceWithExtraConfig;
+import net.minecraft.world.gen.placement.Placement;
+
+public class TreeConfiguredFeatures {
+
+    //cold
+    public static ConfiguredFeature<?, ?> MAPLE_WORLDGEN = configureTree(WorldGenRegistry.maple_worldgen);
+    public static ConfiguredFeature<?, ?> PINENUT_WORLDGEN = configureTree(WorldGenRegistry.pinenut_worldgen);
+    public static ConfiguredFeature<?, ?> ALMOND_WORLDGEN = configureTree(WorldGenRegistry.almond_worldgen);
+    public static ConfiguredFeature<?, ?> APRICOT_WORLDGEN = configureTree(WorldGenRegistry.apricot_worldgen);
+    public static ConfiguredFeature<?, ?> BANANA_WORLDGEN = configureTree(WorldGenRegistry.banana_worldgen);
+    public static ConfiguredFeature<?, ?> CASHEW_WORLDGEN = configureTree(WorldGenRegistry.cashew_worldgen);
+    public static ConfiguredFeature<?, ?> CINNAMON_WORLDGEN = configureTree(WorldGenRegistry.cinnamon_worldgen);
+    public static ConfiguredFeature<?, ?> COCONUT_WORLDGEN = configureTree(WorldGenRegistry.coconut_worldgen);
+    public static ConfiguredFeature<?, ?> DATE_WORLDGEN = configureTree(WorldGenRegistry.date_worldgen);
+    public static ConfiguredFeature<?, ?> DRAGONFRUIT_WORLDGEN = configureTree(WorldGenRegistry.dragonfruit_worldgen);
+    public static ConfiguredFeature<?, ?> DURIAN_WORLDGEN = configureTree(WorldGenRegistry.durian_worldgen);
+    public static ConfiguredFeature<?, ?> FIG_WORLDGEN = configureTree(WorldGenRegistry.fig_worldgen);
+    public static ConfiguredFeature<?, ?> GRAPEFRUIT_WORLDGEN = configureTree(WorldGenRegistry.grapefruit_worldgen);
+    public static ConfiguredFeature<?, ?> LIME_WORLDGEN = configureTree(WorldGenRegistry.lime_worldgen);
+    public static ConfiguredFeature<?, ?> MANGO_WORLDGEN = configureTree(WorldGenRegistry.mango_worldgen);
+    public static ConfiguredFeature<?, ?> OLIVE_WORLDGEN = configureTree(WorldGenRegistry.olive_worldgen);
+    public static ConfiguredFeature<?, ?> PAPAYA_WORLDGEN = configureTree(WorldGenRegistry.papaya_worldgen);
+    public static ConfiguredFeature<?, ?> PAPERBARK_WORLDGEN = configureTree(WorldGenRegistry.paperbark_worldgen);
+    public static ConfiguredFeature<?, ?> PECAN_WORLDGEN = configureTree(WorldGenRegistry.pecan_worldgen);
+    public static ConfiguredFeature<?, ?> PEPPERCORN_WORLDGEN = configureTree(WorldGenRegistry.peppercorn_worldgen);
+    public static ConfiguredFeature<?, ?> PERSIMMON_WORLDGEN = configureTree(WorldGenRegistry.persimmon_worldgen);
+    public static ConfiguredFeature<?, ?> PISTACHIO_WORLDGEN = configureTree(WorldGenRegistry.pistachio_worldgen);
+    public static ConfiguredFeature<?, ?> POMEGRANATE_WORLDGEN = configureTree(WorldGenRegistry.pomegranate_worldgen);
+    public static ConfiguredFeature<?, ?> STARFRUIT_WORLDGEN = configureTree(WorldGenRegistry.starfruit_worldgen);
+    public static ConfiguredFeature<?, ?> VANILLABEAN_WORLDGEN = configureTree(WorldGenRegistry.vanillabean_worldgen);
+
+    //warm
+    public static ConfiguredFeature<?, ?> BREADFRUIT_WORLDGEN = configureTree(WorldGenRegistry.breadfruit_worldgen);
+    public static ConfiguredFeature<?, ?> GUAVA_WORLDGEN = configureTree(WorldGenRegistry.guava_worldgen);
+    public static ConfiguredFeature<?, ?> JACKFRUIT_WORLDGEN = configureTree(WorldGenRegistry.jackfruit_worldgen);
+    public static ConfiguredFeature<?, ?> LYCHEE_WORLDGEN = configureTree(WorldGenRegistry.lychee_worldgen);
+    public static ConfiguredFeature<?, ?> PASSIONFRUIT_WORLDGEN = configureTree(WorldGenRegistry.passionfruit_worldgen);
+    public static ConfiguredFeature<?, ?> RAMBUTAN_WORLDGEN = configureTree(WorldGenRegistry.rambutan_worldgen);
+    public static ConfiguredFeature<?, ?> TAMARIND_WORLDGEN = configureTree(WorldGenRegistry.tamarind_worldgen);
+
+    //temperate
+    public static ConfiguredFeature<?, ?> APPLE_WORLDGEN = configureTree(WorldGenRegistry.apple_worldgen);
+    public static ConfiguredFeature<?, ?> AVOCADO_WORLDGEN = configureTree(WorldGenRegistry.avocado_worldgen);
+    public static ConfiguredFeature<?, ?> CANDLENUT_WORLDGEN = configureTree(WorldGenRegistry.candlenut_worldgen);
+    public static ConfiguredFeature<?, ?> CHERRY_WORLDGEN = configureTree(WorldGenRegistry.cherry_worldgen);
+    public static ConfiguredFeature<?, ?> CHESTNUT_WORLDGEN = configureTree(WorldGenRegistry.chestnut_worldgen);
+    public static ConfiguredFeature<?, ?> GOOSEBERRY_WORLDGEN = configureTree(WorldGenRegistry.gooseberry_worldgen);
+    public static ConfiguredFeature<?, ?> LEMON_WORLDGEN = configureTree(WorldGenRegistry.lemon_worldgen);
+    public static ConfiguredFeature<?, ?> NUTMEG_WORLDGEN = configureTree(WorldGenRegistry.nutmeg_worldgen);
+    public static ConfiguredFeature<?, ?> ORANGE_WORLDGEN = configureTree(WorldGenRegistry.orange_worldgen);
+    public static ConfiguredFeature<?, ?> PEACH_WORLDGEN = configureTree(WorldGenRegistry.peach_worldgen);
+    public static ConfiguredFeature<?, ?> PEAR_WORLDGEN = configureTree(WorldGenRegistry.pear_worldgen);
+    public static ConfiguredFeature<?, ?> PLUM_WORLDGEN = configureTree(WorldGenRegistry.plum_worldgen);
+    public static ConfiguredFeature<?, ?> WALNUT_WORLDGEN = configureTree(WorldGenRegistry.walnut_worldgen);
+    public static ConfiguredFeature<?, ?> HAZELNUT_WORLDGEN = configureTree(WorldGenRegistry.hazelnut_worldgen);
+    public static ConfiguredFeature<?, ?> PAWPAW_WORLDGEN = configureTree(WorldGenRegistry.pawpaw_worldgen);
+    public static ConfiguredFeature<?, ?> SOURSOP_WORLDGEN = configureTree(WorldGenRegistry.soursop_worldgen);
+    public static ConfiguredFeature<?, ?> SPIDERWEB_WORLDGEN = configureTree(WorldGenRegistry.spiderweb_worldgen);
+
+    /*
+     * The default placements set for all trees as none had anything different.
+     * We can easily adjust rate in future for all trees here if needed.
+     */
+    private static ConfiguredFeature<?, ?> configureTree(Feature<NoFeatureConfig> tree){
+        return tree.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
+                .withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
+                .withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT);
+    }
+
+    public static void registerConfiguredFeatures() {
+        Registry<ConfiguredFeature<?, ?>> registry = WorldGenRegistries.CONFIGURED_FEATURE;
+
+        //cold
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "maple_worldgen"), MAPLE_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "pinenut_worldgen"), PINENUT_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "almond_worldgen"), ALMOND_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "apricot_worldgen"), APRICOT_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "banana_worldgen"), BANANA_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "cashew_worldgen"), CASHEW_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "cinnamon_worldgen"), CINNAMON_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "coconut_worldgen"), COCONUT_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "date_worldgen"), DATE_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "dragonfruit_worldgen"), DRAGONFRUIT_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "durian_worldgen"), DURIAN_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "fig_worldgen"), FIG_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "grapefruit_worldgen"), GRAPEFRUIT_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "lime_worldgen"), LIME_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "mango_worldgen"), MANGO_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "olive_worldgen"), OLIVE_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "papaya_worldgen"), PAPAYA_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "paperbark_worldgen"), PAPERBARK_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "pecan_worldgen"), PECAN_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "peppercorn_worldgen"), PEPPERCORN_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "persimmon_worldgen"), PERSIMMON_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "pistachio_worldgen"), PISTACHIO_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "pomegranate_worldgen"), POMEGRANATE_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "starfruit_worldgen"), STARFRUIT_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "vanillabean_worldgen"), VANILLABEAN_WORLDGEN);
+
+        //warm
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "breadfruit_worldgen"), BREADFRUIT_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "guava_worldgen"), GUAVA_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "jackfruit_worldgen"), JACKFRUIT_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "lychee_worldgen"), LYCHEE_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "passionfruit_worldgen"), PASSIONFRUIT_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "rambutan_worldgen"), RAMBUTAN_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "tamarind_worldgen"), TAMARIND_WORLDGEN);
+
+        //temperate
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "apple_worldgen"), APPLE_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "avocado_worldgen"), AVOCADO_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "candlenut_worldgen"), CANDLENUT_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "cherry_worldgen"), CHERRY_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "chestnut_worldgen"), CHESTNUT_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "gooseberry_worldgen"), GOOSEBERRY_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "lemon_worldgen"), LEMON_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "nutmeg_worldgen"), NUTMEG_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "orange_worldgen"), ORANGE_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "peach_worldgen"), PEACH_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "pear_worldgen"), PEAR_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "plum_worldgen"), PLUM_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "walnut_worldgen"), WALNUT_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "hazelnut_worldgen"), HAZELNUT_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "pawpaw_worldgen"), PAWPAW_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "soursop_worldgen"), SOURSOP_WORLDGEN);
+        Registry.register(registry, new ResourceLocation(Pamhc2trees.MOD_ID, "spiderweb_worldgen"), SPIDERWEB_WORLDGEN);
+
+    }
+}

--- a/src/main/java/com/pam/pamhc2trees/init/WarmFruitTreeWorldGenRegistry.java
+++ b/src/main/java/com/pam/pamhc2trees/init/WarmFruitTreeWorldGenRegistry.java
@@ -1,61 +1,45 @@
 package com.pam.pamhc2trees.init;
 
-import java.util.Set;
-
 import net.minecraft.util.RegistryKey;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.gen.GenerationStage;
-import net.minecraft.world.gen.feature.Features;
-import net.minecraft.world.gen.feature.IFeatureConfig;
-import net.minecraft.world.gen.placement.AtSurfaceWithExtraConfig;
-import net.minecraft.world.gen.placement.Placement;
 import net.minecraftforge.common.BiomeDictionary;
 import net.minecraftforge.event.world.BiomeLoadingEvent;
 
+import java.util.Set;
+
 public class WarmFruitTreeWorldGenRegistry {
 	
-	public static void register(BiomeLoadingEvent evt) {
+	public static void addToBiomes(BiomeLoadingEvent evt) {
 		Set<BiomeDictionary.Type> types = BiomeDictionary.getTypes(RegistryKey.getOrCreateKey(Registry.BIOME_KEY, evt.getName()));
 		//almond
 		if (WorldGenRegistry.almond_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.almond_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.ALMOND_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.almond_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.ALMOND_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.almond_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.ALMOND_WORLDGEN);
 			}
 		}
 		//apricot
 		if (WorldGenRegistry.apricot_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.apricot_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.APRICOT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.apricot_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.APRICOT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.apricot_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.APRICOT_WORLDGEN);
 			}
 		}
 
@@ -63,588 +47,420 @@ public class WarmFruitTreeWorldGenRegistry {
 		if (WorldGenRegistry.banana_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.banana_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.BANANA_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.banana_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.BANANA_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.banana_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.BANANA_WORLDGEN);
 			}
 		}
 		//cashew
 		if (WorldGenRegistry.cashew_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.cashew_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.CASHEW_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.cashew_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.CASHEW_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.cashew_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.CASHEW_WORLDGEN);
 			}
 		}
 		//cinnamon
 		if (WorldGenRegistry.cinnamon_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.cinnamon_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.CINNAMON_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.cinnamon_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.CINNAMON_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.cinnamon_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.CINNAMON_WORLDGEN);
 			}
 		}
 		//coconut
 		if (WorldGenRegistry.coconut_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.coconut_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.COCONUT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.coconut_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.COCONUT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.coconut_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.COCONUT_WORLDGEN);
 			}
 		}
 		//date
 		if (WorldGenRegistry.date_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.date_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.DATE_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.date_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.DATE_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.date_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.DATE_WORLDGEN);
 			}
 		}
 		//dragonfruit
 		if (WorldGenRegistry.dragonfruit_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.dragonfruit_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.DRAGONFRUIT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.dragonfruit_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.DRAGONFRUIT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.dragonfruit_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.DRAGONFRUIT_WORLDGEN);
 			}
 		}
 		//durian
 		if (WorldGenRegistry.durian_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.durian_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.DURIAN_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.durian_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.DURIAN_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.durian_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.DURIAN_WORLDGEN);
 			}
 		}
 		//fig
 		if (WorldGenRegistry.fig_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.fig_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.FIG_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.fig_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.FIG_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.fig_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.FIG_WORLDGEN);
 			}
 		}
 		//grapefruit
 		if (WorldGenRegistry.grapefruit_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.grapefruit_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.GRAPEFRUIT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.grapefruit_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.GRAPEFRUIT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.grapefruit_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.GRAPEFRUIT_WORLDGEN);
 			}
 		}
 		//lime
 		if (WorldGenRegistry.lime_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.lime_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.LIME_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.lime_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.LIME_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.lime_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.LIME_WORLDGEN);
 			}
 		}
 		//mango
 		if (WorldGenRegistry.mango_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.mango_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.MANGO_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.mango_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.MANGO_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.mango_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.MANGO_WORLDGEN);
 			}
 		}
 		//olive
 		if (WorldGenRegistry.olive_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.olive_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.OLIVE_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.olive_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.OLIVE_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.olive_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.OLIVE_WORLDGEN);
 			}
 		}
 		//papaya
 		if (WorldGenRegistry.papaya_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.papaya_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PAPAYA_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.papaya_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PAPAYA_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.papaya_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PAPAYA_WORLDGEN);
 			}
 		}
 		//paperbark
 		if (WorldGenRegistry.paperbark_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.paperbark_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PAPERBARK_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.paperbark_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PAPERBARK_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.paperbark_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PAPERBARK_WORLDGEN);
 			}
 		}
 		//pecan
 		if (WorldGenRegistry.pecan_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.pecan_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PECAN_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.pecan_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PECAN_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.pecan_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PECAN_WORLDGEN);
 			}
 		}
 		//peppercorn
 		if (WorldGenRegistry.peppercorn_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.peppercorn_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PEPPERCORN_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.peppercorn_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PEPPERCORN_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.peppercorn_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PEPPERCORN_WORLDGEN);
 			}
 		}
 		//persimmon
 		if (WorldGenRegistry.persimmon_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.persimmon_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PERSIMMON_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.persimmon_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PERSIMMON_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.persimmon_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PERSIMMON_WORLDGEN);
 			}
 		}
 		//pistachio
 		if (WorldGenRegistry.pistachio_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.pistachio_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PISTACHIO_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.pistachio_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PISTACHIO_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.pistachio_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PISTACHIO_WORLDGEN);
 			}
 		}
 		//pomegranate
 		if (WorldGenRegistry.pomegranate_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.pomegranate_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.POMEGRANATE_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.pomegranate_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.POMEGRANATE_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.pomegranate_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.POMEGRANATE_WORLDGEN);
 			}
 		}
 		//starfruit
 		if (WorldGenRegistry.starfruit_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.starfruit_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.STARFRUIT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.starfruit_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.STARFRUIT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.starfruit_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.STARFRUIT_WORLDGEN);
 			}
 		}
 		//vanillabean
 		if (WorldGenRegistry.vanillabean_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.vanillabean_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.VANILLABEAN_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.vanillabean_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.VANILLABEAN_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.vanillabean_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.VANILLABEAN_WORLDGEN);
 			}
 		}
 		//breadfruit
 		if (WorldGenRegistry.breadfruit_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.breadfruit_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.BREADFRUIT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.breadfruit_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.BREADFRUIT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.breadfruit_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.BREADFRUIT_WORLDGEN);
 			}
 		}
 		//guava
 		if (WorldGenRegistry.guava_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.guava_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.GUAVA_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.guava_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.GUAVA_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.guava_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.GUAVA_WORLDGEN);
 			}
 		}
 		//jackfruit
 		if (WorldGenRegistry.jackfruit_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.jackfruit_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.JACKFRUIT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.jackfruit_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.JACKFRUIT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.jackfruit_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.JACKFRUIT_WORLDGEN);
 			}
 		}
 		//lychee
 		if (WorldGenRegistry.lychee_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.lychee_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.LYCHEE_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.lychee_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.LYCHEE_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.lychee_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.LYCHEE_WORLDGEN);
 			}
 		}
 		//passionfruit
 		if (WorldGenRegistry.passionfruit_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.passionfruit_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PASSIONFRUIT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.passionfruit_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PASSIONFRUIT_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.passionfruit_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.PASSIONFRUIT_WORLDGEN);
 			}
 		}
 		//rambutan
 		if (WorldGenRegistry.rambutan_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.rambutan_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.RAMBUTAN_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.rambutan_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.RAMBUTAN_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.rambutan_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.RAMBUTAN_WORLDGEN);
 			}
 		}
 		//tamarind
 		if (WorldGenRegistry.tamarind_worldgen != null) {
 			if (types.contains(BiomeDictionary.Type.JUNGLE)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.tamarind_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.TAMARIND_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.OCEAN)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.tamarind_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.TAMARIND_WORLDGEN);
 			}
 			if (types.contains(BiomeDictionary.Type.SWAMP)) {
 				evt.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION,
-						WorldGenRegistry.tamarind_worldgen.withConfiguration(IFeatureConfig.NO_FEATURE_CONFIG)
-						.withPlacement(Placement.COUNT_EXTRA.configure(new AtSurfaceWithExtraConfig(100, 0F, 0)))
-						.withPlacement(Features.Placements.HEIGHTMAP_PLACEMENT));
+						TreeConfiguredFeatures.TAMARIND_WORLDGEN);
 			}
 		}
 

--- a/src/main/java/com/pam/pamhc2trees/init/WorldGenRegistry.java
+++ b/src/main/java/com/pam/pamhc2trees/init/WorldGenRegistry.java
@@ -78,107 +78,107 @@ public class WorldGenRegistry {
 		IForgeRegistry<Feature<?>> r = event.getRegistry();
 
 		//Temperate Fruits
-		if (EnableConfig.apple_worldgen.get() == true)
+		if (EnableConfig.apple_worldgen.get())
 			apple_worldgen = register(r, new TemperateFruitTreeFeature(NoFeatureConfig.field_236558_a_), "apple_worldgen");
-		if (EnableConfig.avocado_worldgen.get() == true)
+		if (EnableConfig.avocado_worldgen.get())
 			avocado_worldgen = register(r, new TemperateFruitTreeFeature(NoFeatureConfig.field_236558_a_), "avocado_worldgen");
-		if (EnableConfig.candlenut_worldgen.get() == true)
+		if (EnableConfig.candlenut_worldgen.get())
 			candlenut_worldgen = register(r, new TemperateFruitTreeFeature(NoFeatureConfig.field_236558_a_), "candlenut_worldgen");
-		if (EnableConfig.cherry_worldgen.get() == true)
+		if (EnableConfig.cherry_worldgen.get())
 			cherry_worldgen = register(r, new TemperateFruitTreeFeature(NoFeatureConfig.field_236558_a_), "cherry_worldgen");
-		if (EnableConfig.chestnut_worldgen.get() == true)
+		if (EnableConfig.chestnut_worldgen.get())
 			chestnut_worldgen = register(r, new TemperateFruitTreeFeature(NoFeatureConfig.field_236558_a_), "chestnut_worldgen");
-		if (EnableConfig.gooseberry_worldgen.get() == true)
+		if (EnableConfig.gooseberry_worldgen.get())
 			gooseberry_worldgen = register(r, new TemperateFruitTreeFeature(NoFeatureConfig.field_236558_a_), "gooseberry_worldgen");
-		if (EnableConfig.lemon_worldgen.get() == true)
+		if (EnableConfig.lemon_worldgen.get())
 			lemon_worldgen = register(r, new TemperateFruitTreeFeature(NoFeatureConfig.field_236558_a_), "lemon_worldgen");
-		if (EnableConfig.nutmeg_worldgen.get() == true)
+		if (EnableConfig.nutmeg_worldgen.get())
 			nutmeg_worldgen = register(r, new TemperateFruitTreeFeature(NoFeatureConfig.field_236558_a_), "nutmeg_worldgen");
-		if (EnableConfig.orange_worldgen.get() == true)
+		if (EnableConfig.orange_worldgen.get())
 			orange_worldgen = register(r, new TemperateFruitTreeFeature(NoFeatureConfig.field_236558_a_), "orange_worldgen");
-		if (EnableConfig.peach_worldgen.get() == true)
+		if (EnableConfig.peach_worldgen.get())
 			peach_worldgen = register(r, new TemperateFruitTreeFeature(NoFeatureConfig.field_236558_a_), "peach_worldgen");
-		if (EnableConfig.pear_worldgen.get() == true)
+		if (EnableConfig.pear_worldgen.get())
 			pear_worldgen = register(r, new TemperateFruitTreeFeature(NoFeatureConfig.field_236558_a_), "pear_worldgen");
-		if (EnableConfig.plum_worldgen.get() == true)
+		if (EnableConfig.plum_worldgen.get())
 			plum_worldgen = register(r, new TemperateFruitTreeFeature(NoFeatureConfig.field_236558_a_), "plum_worldgen");
-		if (EnableConfig.walnut_worldgen.get() == true)
+		if (EnableConfig.walnut_worldgen.get())
 			walnut_worldgen = register(r, new TemperateFruitTreeFeature(NoFeatureConfig.field_236558_a_), "walnut_worldgen");
-		if (EnableConfig.spiderweb_worldgen.get() == true)
+		if (EnableConfig.spiderweb_worldgen.get())
 			spiderweb_worldgen = register(r, new TemperateFruitTreeFeature(NoFeatureConfig.field_236558_a_), "spiderweb_worldgen");
-		if (EnableConfig.hazelnut_worldgen.get() == true)
+		if (EnableConfig.hazelnut_worldgen.get())
 			hazelnut_worldgen = register(r, new TemperateFruitTreeFeature(NoFeatureConfig.field_236558_a_), "hazelnut_worldgen");
-		if (EnableConfig.pawpaw_worldgen.get() == true)
+		if (EnableConfig.pawpaw_worldgen.get())
 			pawpaw_worldgen = register(r, new TemperateFruitTreeFeature(NoFeatureConfig.field_236558_a_), "pawpaw_worldgen");
-		if (EnableConfig.soursop_worldgen.get() == true)
+		if (EnableConfig.soursop_worldgen.get())
 			soursop_worldgen = register(r, new TemperateFruitTreeFeature(NoFeatureConfig.field_236558_a_), "soursop_worldgen");
 		
 		//Warm Fruits
-		if (EnableConfig.almond_worldgen.get() == true)
+		if (EnableConfig.almond_worldgen.get())
 			almond_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "almond_worldgen");
-		if (EnableConfig.apricot_worldgen.get() == true)
+		if (EnableConfig.apricot_worldgen.get())
 			apricot_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "apricot_worldgen");
-		if (EnableConfig.banana_worldgen.get() == true)
+		if (EnableConfig.banana_worldgen.get())
 			banana_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "banana_worldgen");
-		if (EnableConfig.cashew_worldgen.get() == true)
+		if (EnableConfig.cashew_worldgen.get())
 			cashew_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "cashew_worldgen");
-		if (EnableConfig.cinnamon_worldgen.get() == true)
+		if (EnableConfig.cinnamon_worldgen.get())
 			cinnamon_worldgen = register(r, new WarmLogFruitTreeFeature(NoFeatureConfig.field_236558_a_), "cinnamon_worldgen");
-		if (EnableConfig.coconut_worldgen.get() == true)
+		if (EnableConfig.coconut_worldgen.get())
 			coconut_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "coconut_worldgen");
-		if (EnableConfig.date_worldgen.get() == true)
+		if (EnableConfig.date_worldgen.get())
 			date_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "date_worldgen");
-		if (EnableConfig.dragonfruit_worldgen.get() == true)
+		if (EnableConfig.dragonfruit_worldgen.get())
 			dragonfruit_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "dragonfruit_worldgen");
-		if (EnableConfig.durian_worldgen.get() == true)
+		if (EnableConfig.durian_worldgen.get())
 			durian_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "durian_worldgen");
-		if (EnableConfig.fig_worldgen.get() == true)
+		if (EnableConfig.fig_worldgen.get())
 			fig_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "fig_worldgen");
-		if (EnableConfig.grapefruit_worldgen.get() == true)
+		if (EnableConfig.grapefruit_worldgen.get())
 			grapefruit_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "grapefruit_worldgen");
-		if (EnableConfig.lime_worldgen.get() == true)
+		if (EnableConfig.lime_worldgen.get())
 			lime_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "lime_worldgen");
-		if (EnableConfig.mango_worldgen.get() == true)
+		if (EnableConfig.mango_worldgen.get())
 			mango_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "mango_worldgen");
-		if (EnableConfig.olive_worldgen.get() == true)
+		if (EnableConfig.olive_worldgen.get())
 			olive_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "olive_worldgen");
-		if (EnableConfig.papaya_worldgen.get() == true)
+		if (EnableConfig.papaya_worldgen.get())
 			papaya_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "papaya_worldgen");
-		if (EnableConfig.paperbark_worldgen.get() == true)
+		if (EnableConfig.paperbark_worldgen.get())
 			paperbark_worldgen = register(r, new WarmLogFruitTreeFeature(NoFeatureConfig.field_236558_a_), "paperbark_worldgen");
-		if (EnableConfig.pecan_worldgen.get() == true)
+		if (EnableConfig.pecan_worldgen.get())
 			pecan_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "pecan_worldgen");
-		if (EnableConfig.peppercorn_worldgen.get() == true)
+		if (EnableConfig.peppercorn_worldgen.get())
 			peppercorn_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "peppercorn_worldgen");
-		if (EnableConfig.persimmon_worldgen.get() == true)
+		if (EnableConfig.persimmon_worldgen.get())
 			persimmon_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "persimmon_worldgen");
-		if (EnableConfig.pistachio_worldgen.get() == true)
+		if (EnableConfig.pistachio_worldgen.get())
 			pistachio_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "pistachio_worldgen");
-		if (EnableConfig.pomegranate_worldgen.get() == true)
+		if (EnableConfig.pomegranate_worldgen.get())
 			pomegranate_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "pomegranate_worldgen");
-		if (EnableConfig.starfruit_worldgen.get() == true)
+		if (EnableConfig.starfruit_worldgen.get())
 			starfruit_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "starfruit_worldgen");
-		if (EnableConfig.vanillabean_worldgen.get() == true)
+		if (EnableConfig.vanillabean_worldgen.get())
 			vanillabean_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "vanillabean_worldgen");
-		if (EnableConfig.breadfruit_worldgen.get() == true)
+		if (EnableConfig.breadfruit_worldgen.get())
 			breadfruit_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "breadfruit_worldgen");
-		if (EnableConfig.guava_worldgen.get() == true)
+		if (EnableConfig.guava_worldgen.get())
 			guava_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "guava_worldgen");
-		if (EnableConfig.jackfruit_worldgen.get() == true)
+		if (EnableConfig.jackfruit_worldgen.get())
 			jackfruit_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "jackfruit_worldgen");
-		if (EnableConfig.lychee_worldgen.get() == true)
+		if (EnableConfig.lychee_worldgen.get())
 			lychee_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "lychee_worldgen");
-		if (EnableConfig.passionfruit_worldgen.get() == true)
+		if (EnableConfig.passionfruit_worldgen.get())
 			passionfruit_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "passionfruit_worldgen");
-		if (EnableConfig.rambutan_worldgen.get() == true)
+		if (EnableConfig.rambutan_worldgen.get())
 			rambutan_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "rambutan_worldgen");
-		if (EnableConfig.tamarind_worldgen.get() == true)
+		if (EnableConfig.tamarind_worldgen.get())
 			tamarind_worldgen = register(r, new WarmFruitTreeFeature(NoFeatureConfig.field_236558_a_), "tamarind_worldgen");
 		
 		//Cold Fruits
-		if (EnableConfig.maple_worldgen.get() == true)
+		if (EnableConfig.maple_worldgen.get())
 			maple_worldgen = register(r, new ColdLogFruitTreeFeature(NoFeatureConfig.field_236558_a_), "maple_worldgen");
-		if (EnableConfig.pinenut_worldgen.get() == true)
+		if (EnableConfig.pinenut_worldgen.get())
 			pinenut_worldgen = register(r, new ColdFruitTreeFeature(NoFeatureConfig.field_236558_a_), "pinenut_worldgen");
 	}
 

--- a/src/main/java/com/pam/pamhc2trees/worldgen/ColdFruitTreeFeature.java
+++ b/src/main/java/com/pam/pamhc2trees/worldgen/ColdFruitTreeFeature.java
@@ -237,7 +237,7 @@ public class ColdFruitTreeFeature extends Feature<NoFeatureConfig> {
 	
 	private static BlockState getLeaves(int verify)
 	{
-		return Blocks.SPRUCE_LEAVES.getDefaultState().with(BlockStateProperties.DISTANCE_1_7, Integer.valueOf(1));
+		return Blocks.SPRUCE_LEAVES.getDefaultState().with(BlockStateProperties.DISTANCE_1_7, 1);
 	}
 	
 	private static BlockState getTrunk(int verify)
@@ -248,7 +248,7 @@ public class ColdFruitTreeFeature extends Feature<NoFeatureConfig> {
 	private static BlockState getFruit(int verify, Random random)
 	{
 		int i = random.nextInt(2);
-			return BlockRegistry.pampinenut.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampinenut.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 
 		
 	}

--- a/src/main/java/com/pam/pamhc2trees/worldgen/ColdLogFruitTreeFeature.java
+++ b/src/main/java/com/pam/pamhc2trees/worldgen/ColdLogFruitTreeFeature.java
@@ -204,7 +204,7 @@ public class ColdLogFruitTreeFeature extends Feature<NoFeatureConfig> {
 	
 	private static BlockState getLeaves(int verify)
 	{
-		return Blocks.SPRUCE_LEAVES.getDefaultState().with(BlockStateProperties.DISTANCE_1_7, Integer.valueOf(1));
+		return Blocks.SPRUCE_LEAVES.getDefaultState().with(BlockStateProperties.DISTANCE_1_7, 1);
 	}
 	
 	private static BlockState getTrunk(int verify)
@@ -215,7 +215,7 @@ public class ColdLogFruitTreeFeature extends Feature<NoFeatureConfig> {
 	private static BlockState getFruit(int verify, Random random)
 	{
 		int i = random.nextInt(2);
-			return BlockRegistry.pammaple.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pammaple.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 
 		
 	}

--- a/src/main/java/com/pam/pamhc2trees/worldgen/TemperateFruitTreeFeature.java
+++ b/src/main/java/com/pam/pamhc2trees/worldgen/TemperateFruitTreeFeature.java
@@ -226,7 +226,7 @@ public class TemperateFruitTreeFeature extends Feature<NoFeatureConfig> {
 	
 	private static BlockState getLeaves()
 	{
-		return Blocks.OAK_LEAVES.getDefaultState().with(BlockStateProperties.DISTANCE_1_7, Integer.valueOf(1));
+		return Blocks.OAK_LEAVES.getDefaultState().with(BlockStateProperties.DISTANCE_1_7, 1);
 	}
 	
 	private static BlockState getTrunk()
@@ -240,57 +240,57 @@ public class TemperateFruitTreeFeature extends Feature<NoFeatureConfig> {
 		switch (verify) {
 		case 1:
 			if (EnableConfig.apple_worldgen != null)
-			return BlockRegistry.pamapple.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamapple.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 2:
 			if (EnableConfig.avocado_worldgen != null)
-			return BlockRegistry.pamavocado.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamavocado.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 3:
 			if (EnableConfig.candlenut_worldgen != null)
-			return BlockRegistry.pamcandlenut.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamcandlenut.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 4:
 			if (EnableConfig.cherry_worldgen != null)
-			return BlockRegistry.pamcherry.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamcherry.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 5:
 			if (EnableConfig.chestnut_worldgen != null)
-			return BlockRegistry.pamchestnut.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamchestnut.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 6:
 			if (EnableConfig.gooseberry_worldgen != null)
-			return BlockRegistry.pamgooseberry.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamgooseberry.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 7:
 			if (EnableConfig.lemon_worldgen != null)
-			return BlockRegistry.pamlemon.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamlemon.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 8:
 			if (EnableConfig.nutmeg_worldgen != null)
-			return BlockRegistry.pamnutmeg.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamnutmeg.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 9:
 			if (EnableConfig.orange_worldgen != null)
-			return BlockRegistry.pamorange.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamorange.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 10:
 			if (EnableConfig.peach_worldgen != null)
-			return BlockRegistry.pampeach.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampeach.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 11:
 			if (EnableConfig.pear_worldgen != null)
-			return BlockRegistry.pampear.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampear.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 12:
 			if (EnableConfig.plum_worldgen != null)
-			return BlockRegistry.pamplum.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamplum.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 13:
 			if (EnableConfig.walnut_worldgen != null)
-			return BlockRegistry.pamwalnut.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamwalnut.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 14:
 			if (EnableConfig.spiderweb_worldgen != null)
-			return BlockRegistry.pamspiderweb.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamspiderweb.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 15:
 			if (EnableConfig.hazelnut_worldgen != null)
-			return BlockRegistry.pamhazelnut.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamhazelnut.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 16:
 			if (EnableConfig.pawpaw_worldgen != null)
-			return BlockRegistry.pampawpaw.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampawpaw.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 17:
 			if (EnableConfig.soursop_worldgen != null)
-			return BlockRegistry.pamsoursop.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamsoursop.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		default:
-			return BlockRegistry.pamapple.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamapple.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		}
 	}
 }

--- a/src/main/java/com/pam/pamhc2trees/worldgen/WarmFruitTreeFeature.java
+++ b/src/main/java/com/pam/pamhc2trees/worldgen/WarmFruitTreeFeature.java
@@ -128,7 +128,7 @@ public class WarmFruitTreeFeature extends Feature<NoFeatureConfig> {
 	
 	private static BlockState getLeaves(int verify)
 	{
-		return Blocks.JUNGLE_LEAVES.getDefaultState().with(BlockStateProperties.DISTANCE_1_7, Integer.valueOf(1));
+		return Blocks.JUNGLE_LEAVES.getDefaultState().with(BlockStateProperties.DISTANCE_1_7, 1);
 	}
 	
 	private static BlockState getTrunk(int verify)
@@ -142,90 +142,90 @@ public class WarmFruitTreeFeature extends Feature<NoFeatureConfig> {
 		switch (verify) {
 		case 1:
 			if (EnableConfig.almond_worldgen != null)
-			return BlockRegistry.pamalmond.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamalmond.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 2:
 			if (EnableConfig.apricot_worldgen != null)
-			return BlockRegistry.pamapricot.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamapricot.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 3:
 			if (EnableConfig.banana_worldgen != null)
-			return BlockRegistry.pambanana.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pambanana.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 4:
 			if (EnableConfig.cashew_worldgen != null)
-			return BlockRegistry.pamcashew.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamcashew.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 5:
 			if (EnableConfig.coconut_worldgen != null)
-			return BlockRegistry.pamcoconut.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamcoconut.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 6:
 			if (EnableConfig.date_worldgen != null)
-			return BlockRegistry.pamdate.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamdate.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 7:
 			if (EnableConfig.dragonfruit_worldgen != null)
-			return BlockRegistry.pamdragonfruit.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamdragonfruit.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 8:
 			if (EnableConfig.durian_worldgen != null)
-			return BlockRegistry.pamdurian.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamdurian.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 9:
 			if (EnableConfig.fig_worldgen != null)
-			return BlockRegistry.pamfig.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamfig.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 10:
 			if (EnableConfig.grapefruit_worldgen != null)
-			return BlockRegistry.pamgrapefruit.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamgrapefruit.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 11:
 			if (EnableConfig.lime_worldgen != null)
-			return BlockRegistry.pamlime.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamlime.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 12:
 			if (EnableConfig.mango_worldgen != null)
-			return BlockRegistry.pammango.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pammango.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 13:
 			if (EnableConfig.olive_worldgen != null)
-			return BlockRegistry.pamolive.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamolive.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 14:
 			if (EnableConfig.papaya_worldgen != null)
-			return BlockRegistry.pampapaya.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampapaya.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 15:
 			if (EnableConfig.pecan_worldgen != null)
-			return BlockRegistry.pampecan.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampecan.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 16:
 			if (EnableConfig.peppercorn_worldgen != null)
-			return BlockRegistry.pampeppercorn.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampeppercorn.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 17:
 			if (EnableConfig.persimmon_worldgen != null)
-			return BlockRegistry.pampersimmon.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampersimmon.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 18:
 			if (EnableConfig.pistachio_worldgen != null)
-			return BlockRegistry.pampistachio.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampistachio.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 19:
 			if (EnableConfig.pomegranate_worldgen != null)
-			return BlockRegistry.pampomegranate.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampomegranate.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 20:
 			if (EnableConfig.starfruit_worldgen != null)
-			return BlockRegistry.pamstarfruit.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamstarfruit.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 21:
 			if (EnableConfig.vanillabean_worldgen != null)
-			return BlockRegistry.pamvanillabean.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamvanillabean.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 22:
 			if (EnableConfig.breadfruit_worldgen != null)
-			return BlockRegistry.pambreadfruit.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pambreadfruit.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 23:
 			if (EnableConfig.guava_worldgen != null)
-			return BlockRegistry.pamguava.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamguava.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 24:
 			if (EnableConfig.jackfruit_worldgen != null)
-			return BlockRegistry.pamjackfruit.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamjackfruit.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 25:
 			if (EnableConfig.lychee_worldgen != null)
-			return BlockRegistry.pamlychee.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamlychee.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 26:
 			if (EnableConfig.passionfruit_worldgen != null)
-			return BlockRegistry.pampassionfruit.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampassionfruit.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 27:
 			if (EnableConfig.rambutan_worldgen != null)
-			return BlockRegistry.pamrambutan.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamrambutan.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 28:
 			if (EnableConfig.tamarind_worldgen != null)
-			return BlockRegistry.pamtamarind.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamtamarind.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		default:
-			return BlockRegistry.pamalmond.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamalmond.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		}
 	}
 }

--- a/src/main/java/com/pam/pamhc2trees/worldgen/WarmLogFruitTreeFeature.java
+++ b/src/main/java/com/pam/pamhc2trees/worldgen/WarmLogFruitTreeFeature.java
@@ -105,7 +105,7 @@ public class WarmLogFruitTreeFeature extends Feature<NoFeatureConfig> {
 	
 	private static BlockState getLeaves(int verify)
 	{
-		return Blocks.JUNGLE_LEAVES.getDefaultState().with(BlockStateProperties.DISTANCE_1_7, Integer.valueOf(1));
+		return Blocks.JUNGLE_LEAVES.getDefaultState().with(BlockStateProperties.DISTANCE_1_7, 1);
 	}
 	
 	private static BlockState getTrunk(int verify)
@@ -119,12 +119,12 @@ public class WarmLogFruitTreeFeature extends Feature<NoFeatureConfig> {
 		switch (verify) {
 		case 1:
 			if (EnableConfig.cinnamon_worldgen != null)
-			return BlockRegistry.pamcinnamon.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamcinnamon.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 2:
 			if (EnableConfig.paperbark_worldgen != null)
-			return BlockRegistry.pampaperbark.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampaperbark.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		default:
-			return BlockRegistry.pamalmond.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamalmond.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		}
 	}
 }

--- a/src/main/java/com/pam/pamhc2trees/worldgen/sapling/ColdFruitTreeFeatureSapling.java
+++ b/src/main/java/com/pam/pamhc2trees/worldgen/sapling/ColdFruitTreeFeatureSapling.java
@@ -237,7 +237,7 @@ public class ColdFruitTreeFeatureSapling extends Feature<NoFeatureConfig> {
 	
 	private static BlockState getLeaves(int verify)
 	{
-		return Blocks.SPRUCE_LEAVES.getDefaultState().with(BlockStateProperties.DISTANCE_1_7, Integer.valueOf(1));
+		return Blocks.SPRUCE_LEAVES.getDefaultState().with(BlockStateProperties.DISTANCE_1_7, 1);
 	}
 	
 	private static BlockState getTrunk(int verify)

--- a/src/main/java/com/pam/pamhc2trees/worldgen/sapling/ColdLogFruitTreeFeatureSapling.java
+++ b/src/main/java/com/pam/pamhc2trees/worldgen/sapling/ColdLogFruitTreeFeatureSapling.java
@@ -204,7 +204,7 @@ public class ColdLogFruitTreeFeatureSapling extends Feature<NoFeatureConfig> {
 	
 	private static BlockState getLeaves(int verify)
 	{
-		return Blocks.SPRUCE_LEAVES.getDefaultState().with(BlockStateProperties.DISTANCE_1_7, Integer.valueOf(1));
+		return Blocks.SPRUCE_LEAVES.getDefaultState().with(BlockStateProperties.DISTANCE_1_7, 1);
 	}
 	
 	private static BlockState getTrunk(int verify)

--- a/src/main/java/com/pam/pamhc2trees/worldgen/sapling/TemperateFruitTreeFeatureSapling.java
+++ b/src/main/java/com/pam/pamhc2trees/worldgen/sapling/TemperateFruitTreeFeatureSapling.java
@@ -226,7 +226,7 @@ public class TemperateFruitTreeFeatureSapling extends Feature<NoFeatureConfig> {
 	
 	private static BlockState getLeaves()
 	{
-		return Blocks.OAK_LEAVES.getDefaultState().with(BlockStateProperties.DISTANCE_1_7, Integer.valueOf(1));
+		return Blocks.OAK_LEAVES.getDefaultState().with(BlockStateProperties.DISTANCE_1_7, 1);
 	}
 	
 	private static BlockState getTrunk()
@@ -240,57 +240,57 @@ public class TemperateFruitTreeFeatureSapling extends Feature<NoFeatureConfig> {
 		switch (verify) {
 		case 1:
 			if (EnableConfig.apple_worldgen != null)
-			return BlockRegistry.pamapple.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamapple.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 2:
 			if (EnableConfig.avocado_worldgen != null)
-			return BlockRegistry.pamavocado.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamavocado.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 3:
 			if (EnableConfig.candlenut_worldgen != null)
-			return BlockRegistry.pamcandlenut.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamcandlenut.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 4:
 			if (EnableConfig.cherry_worldgen != null)
-			return BlockRegistry.pamcherry.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamcherry.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 5:
 			if (EnableConfig.chestnut_worldgen != null)
-			return BlockRegistry.pamchestnut.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamchestnut.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 6:
 			if (EnableConfig.gooseberry_worldgen != null)
-			return BlockRegistry.pamgooseberry.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamgooseberry.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 7:
 			if (EnableConfig.lemon_worldgen != null)
-			return BlockRegistry.pamlemon.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamlemon.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 8:
 			if (EnableConfig.nutmeg_worldgen != null)
-			return BlockRegistry.pamnutmeg.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamnutmeg.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 9:
 			if (EnableConfig.orange_worldgen != null)
-			return BlockRegistry.pamorange.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamorange.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 10:
 			if (EnableConfig.peach_worldgen != null)
-			return BlockRegistry.pampeach.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampeach.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 11:
 			if (EnableConfig.pear_worldgen != null)
-			return BlockRegistry.pampear.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampear.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 12:
 			if (EnableConfig.plum_worldgen != null)
-			return BlockRegistry.pamplum.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamplum.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 13:
 			if (EnableConfig.walnut_worldgen != null)
-			return BlockRegistry.pamwalnut.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamwalnut.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 14:
 			if (EnableConfig.spiderweb_worldgen != null)
-			return BlockRegistry.pamspiderweb.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamspiderweb.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 15:
 			if (EnableConfig.hazelnut_worldgen != null)
-			return BlockRegistry.pamhazelnut.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamhazelnut.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 16:
 			if (EnableConfig.pawpaw_worldgen != null)
-			return BlockRegistry.pampawpaw.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampawpaw.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 17:
 			if (EnableConfig.soursop_worldgen != null)
-			return BlockRegistry.pamsoursop.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamsoursop.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		default:
-			return BlockRegistry.pamapple.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamapple.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		}
 	}
 }

--- a/src/main/java/com/pam/pamhc2trees/worldgen/sapling/WarmFruitTreeFeatureSapling.java
+++ b/src/main/java/com/pam/pamhc2trees/worldgen/sapling/WarmFruitTreeFeatureSapling.java
@@ -128,7 +128,7 @@ public class WarmFruitTreeFeatureSapling extends Feature<NoFeatureConfig> {
 	
 	private static BlockState getLeaves(int verify)
 	{
-		return Blocks.JUNGLE_LEAVES.getDefaultState().with(BlockStateProperties.DISTANCE_1_7, Integer.valueOf(1));
+		return Blocks.JUNGLE_LEAVES.getDefaultState().with(BlockStateProperties.DISTANCE_1_7, 1);
 	}
 	
 	private static BlockState getTrunk(int verify)
@@ -142,90 +142,90 @@ public class WarmFruitTreeFeatureSapling extends Feature<NoFeatureConfig> {
 		switch (verify) {
 		case 1:
 			if (EnableConfig.almond_worldgen != null)
-			return BlockRegistry.pamalmond.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamalmond.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 2:
 			if (EnableConfig.apricot_worldgen != null)
-			return BlockRegistry.pamapricot.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamapricot.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 3:
 			if (EnableConfig.banana_worldgen != null)
-			return BlockRegistry.pambanana.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pambanana.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 4:
 			if (EnableConfig.cashew_worldgen != null)
-			return BlockRegistry.pamcashew.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamcashew.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 5:
 			if (EnableConfig.coconut_worldgen != null)
-			return BlockRegistry.pamcoconut.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamcoconut.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 6:
 			if (EnableConfig.date_worldgen != null)
-			return BlockRegistry.pamdate.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamdate.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 7:
 			if (EnableConfig.dragonfruit_worldgen != null)
-			return BlockRegistry.pamdragonfruit.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamdragonfruit.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 8:
 			if (EnableConfig.durian_worldgen != null)
-			return BlockRegistry.pamdurian.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamdurian.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 9:
 			if (EnableConfig.fig_worldgen != null)
-			return BlockRegistry.pamfig.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamfig.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 10:
 			if (EnableConfig.grapefruit_worldgen != null)
-			return BlockRegistry.pamgrapefruit.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamgrapefruit.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 11:
 			if (EnableConfig.lime_worldgen != null)
-			return BlockRegistry.pamlime.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamlime.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 12:
 			if (EnableConfig.mango_worldgen != null)
-			return BlockRegistry.pammango.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pammango.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 13:
 			if (EnableConfig.olive_worldgen != null)
-			return BlockRegistry.pamolive.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamolive.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 14:
 			if (EnableConfig.papaya_worldgen != null)
-			return BlockRegistry.pampapaya.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampapaya.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 15:
 			if (EnableConfig.pecan_worldgen != null)
-			return BlockRegistry.pampecan.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampecan.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 16:
 			if (EnableConfig.peppercorn_worldgen != null)
-			return BlockRegistry.pampeppercorn.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampeppercorn.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 17:
 			if (EnableConfig.persimmon_worldgen != null)
-			return BlockRegistry.pampersimmon.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampersimmon.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 18:
 			if (EnableConfig.pistachio_worldgen != null)
-			return BlockRegistry.pampistachio.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampistachio.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 19:
 			if (EnableConfig.pomegranate_worldgen != null)
-			return BlockRegistry.pampomegranate.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampomegranate.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 20:
 			if (EnableConfig.starfruit_worldgen != null)
-			return BlockRegistry.pamstarfruit.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamstarfruit.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 21:
 			if (EnableConfig.vanillabean_worldgen != null)
-			return BlockRegistry.pamvanillabean.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamvanillabean.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 22:
 			if (EnableConfig.breadfruit_worldgen != null)
-			return BlockRegistry.pambreadfruit.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pambreadfruit.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 23:
 			if (EnableConfig.guava_worldgen != null)
-			return BlockRegistry.pamguava.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamguava.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 24:
 			if (EnableConfig.jackfruit_worldgen != null)
-			return BlockRegistry.pamjackfruit.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamjackfruit.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 25:
 			if (EnableConfig.lychee_worldgen != null)
-			return BlockRegistry.pamlychee.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamlychee.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 26:
 			if (EnableConfig.passionfruit_worldgen != null)
-			return BlockRegistry.pampassionfruit.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampassionfruit.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 27:
 			if (EnableConfig.rambutan_worldgen != null)
-			return BlockRegistry.pamrambutan.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamrambutan.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 28:
 			if (EnableConfig.tamarind_worldgen != null)
-			return BlockRegistry.pamtamarind.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamtamarind.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		default:
-			return BlockRegistry.pamalmond.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamalmond.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		}
 	}
 }

--- a/src/main/java/com/pam/pamhc2trees/worldgen/sapling/WarmLogFruitTreeFeatureSapling.java
+++ b/src/main/java/com/pam/pamhc2trees/worldgen/sapling/WarmLogFruitTreeFeatureSapling.java
@@ -106,7 +106,7 @@ public class WarmLogFruitTreeFeatureSapling extends Feature<NoFeatureConfig> {
 	
 	private static BlockState getLeaves(int verify)
 	{
-		return Blocks.JUNGLE_LEAVES.getDefaultState().with(BlockStateProperties.DISTANCE_1_7, Integer.valueOf(1));
+		return Blocks.JUNGLE_LEAVES.getDefaultState().with(BlockStateProperties.DISTANCE_1_7, 1);
 	}
 	
 	private static BlockState getTrunk(int verify)
@@ -120,12 +120,12 @@ public class WarmLogFruitTreeFeatureSapling extends Feature<NoFeatureConfig> {
 		switch (verify) {
 		case 1:
 			if (EnableConfig.cinnamon_worldgen != null)
-			return BlockRegistry.pamcinnamon.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamcinnamon.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		case 2:
 			if (EnableConfig.paperbark_worldgen != null)
-			return BlockRegistry.pampaperbark.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pampaperbark.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		default:
-			return BlockRegistry.pamalmond.getDefaultState().with(BlockStateProperties.AGE_0_7, Integer.valueOf(i));
+			return BlockRegistry.pamalmond.getDefaultState().with(BlockStateProperties.AGE_0_7, i);
 		}
 	}
 }


### PR DESCRIPTION
All trees configurefeatures are now properly registered and the code is cleaned up a bit so that they are a bit less verbose!

I also changed `Integer.valueOf(i)` to just `i` to reduce unneeded boxing. The vanilla code with that stuff in is probably just deobfuscation artifacts. Also simplified `if (EnableConfig.pinenut_worldgen.get() == true)` to just `if (EnableConfig.pinenut_worldgen.get())`

I also found as I was registering the ConfiguredFeatures that the spiderweb tree was actually not spawning before. Now it does!

I also added gitignore + adjusted build.gradle so that run client has the mod on so i could test my pr. You can revert these two changes if you want to.

Hopefully this helps!